### PR TITLE
correção erros com pontuações

### DIFF
--- a/text/1009.text
+++ b/text/1009.text
@@ -69,7 +69,7 @@ energia elétrica Cuiabá-Sinop, afirmou que queria ser o primeiro brasileiro a
 lançar a candidatura de Itamar Franco à presidência da República em 1998.
 
 Em outubro de 1996, candidatou-se a prefeito de Várzea Grande pelo PFL. Eleito, 
-tomou posse em janeiro de 1997.No pleito realizado em 2000, foi reeleito 
+tomou posse em janeiro de 1997. No pleito realizado em 2000, foi reeleito 
 prefeito de Várzea Grande. Com o fim do mandato, e, sem ter feito seu sucessor 
 nas eleições de 2004, deixou a prefeitura no fim daquele ano.
 

--- a/text/11007.text
+++ b/text/11007.text
@@ -59,7 +59,7 @@ chamada “máfia dos sanguessugas”, grupo que incluía parlamentares acusados
 criar emendas destinadas à compra superfaturada de ambulâncias, entre os anos 
 de 2002 e 2003. Nessa ocasião, teve seu nome incluído na lista dos investigados 
 pela Comissão Parlamentar de Inquérito (CPI) que apurou o episódio. Em matéria 
-publicada pela «Folha de S.Paulo» sobre seu possível envolvimento no caso, 
+publicada pela «Folha de S. Paulo» sobre seu possível envolvimento no caso, 
 Elias negou sua participação no esquema. O relatório final da CPI dos 
 Sanguessugas, aprovado em dezembro de 2006, pediu o indiciamento de dez 
 pessoas, enumerou prefeituras que teriam sido alvos do grupo e apontou o 

--- a/text/11149.text
+++ b/text/11149.text
@@ -18,7 +18,7 @@ dos médicos. Em 1979 ajudou a fundar o diretório local do Partido
 Democrático Trabalhista (PDT). Elegeu-se prefeito de São Luís em 1988,
 depois em 1996, reelegendo-se em seguida, nas eleições de 2000.
 Conquistou o título de melhor prefeito do Brasil, indicado por pesquisas
-do jornal «Folha de S.Paulo». Renunciou ao seu mandato como prefeito de
+do jornal «Folha de S. Paulo». Renunciou ao seu mandato como prefeito de
 São Luís em 2002 para concorrer ao governo do estado, mas não se elegeu,
 sendo derrotado por José Reinaldo Tavares, do Partido da Frente Liberal
 (PFL).

--- a/text/11158.text
+++ b/text/11158.text
@@ -86,7 +86,7 @@ expressão “elite branca” ao se referir à passeata realizada no dia 29
 daquele mês pelo movimento “Cansei”. O movimento, segundo afirmou em
 entrevista à revista on-line «TerraMagazine», fora organizado por
 pessoas que  tinham uma visão elitista da sociedade e “cansei” era um
-termo próprio de “dondocas enfadadas com suas vidas enfadonhas.” Em
+termo próprio de “dondocas enfadadas com suas vidas enfadonhas”. Em
 agosto ocorreu nova onda de ataques nas ruas de São Paulo: ônibus e
 prédios públicos foram incendiados, e muitos hospitais, escolas, centros
 comerciais e unidades de transporte público deixaram de funcionar por

--- a/text/11184.text
+++ b/text/11184.text
@@ -41,13 +41,13 @@ influentes do Rio Grande do Sul. Neste mesmo ano, candidatou-se novamente à
 prefeitura de Porto Alegre, quando foi acusado de usar verbas públicas 
 destinadas a divulgação de atividades legislativas para sua campanha eleitoral. 
 Lorenzoni recebeu 9,97% dos votos válidos e terminou o primeiro turno em 
-terceiro lugar.O candidato eleito, no segundo turno, foi Raul Pont do Partido 
+terceiro lugar. O candidato eleito, no segundo turno, foi Raul Pont do Partido 
 dos Trabalhadores (PT), seguido por JoseFogaça, do Partido Popular Socialista 
 (PPS).
 
 Em 2005, Ônix Lorenzoni foi vice-presidente da Comissão Parlamentar Mista de 
 Inquérito (CPMI) da Terra, que investigou as denúncias publicadas pelo jornal 
-«Folha de S.Paulo», em 17 de outubro de 2004 sobre a relação entre José Rainha 
+«Folha de S. Paulo», em 17 de outubro de 2004 sobre a relação entre José Rainha 
 Jr. e as irregularidades na conta da Cocamp (a cooperativa do MST no Pontal do 
 Paranapanema), que estava sob investigação do Ministério Público desde 2001.  
 Lorenzoni também ficou conhecido pela sua atuação na CPI dos Correios, criada 

--- a/text/11189.text
+++ b/text/11189.text
@@ -18,7 +18,7 @@ econômico pelo Banco Nacional de Desenvolvimento Econômico e Social
 (BNDES), e em economia industrial, pela UFRJ.
 
 Em 1974 filiou-se ao Movimento Democrático Brasileiro
-(MDB).Ingressou na vida política atuando como coordenador geral do
+(MDB). Ingressou na vida política atuando como coordenador geral do
 Centro Acadêmico da Escola de Engenharia da UFRJ, função que desempenhou
 entre 1977 e 1979. No ano seguinte ingressou no BNDES, tendo sido
 diretor da associação dos funcionários dessa instituição (1981-1983) e

--- a/text/11197.text
+++ b/text/11197.text
@@ -52,7 +52,7 @@ Financeira e Controle, e de Legislação Participativa, além de várias comiss�
 especiais.
 
 Nas eleições de outubro de 2010, foi reeleito para o seu quarto mandato 
-consecutivo como deputado federal, o qual assumiu em Fevereiro de 2011.Em 2012, 
+consecutivo como deputado federal, o qual assumiu em Fevereiro de 2011. Em 2012, 
 lançou candidatura para a prefeitura de Uberlândia (MG), quando foi eleito no 
 primeiro turno do pleito realizado em Outubro, com 236.418 votos, equivalentes 
 a 68,72% dos votos válidos. Em janeiro de 2013, renunciou ao mandato de 

--- a/text/11244.text
+++ b/text/11244.text
@@ -41,5 +41,5 @@ Câmara Ítalo-Brasileira de Comércio e Indústria e presidente do Comitê
 de Investimento. Foi também conselheiro do Instituto de Estudos para
 Desenvolvimento Industrial (IEDI) e membro do Conselho de Administração
 da Fundação Bienal de São Paulo. Ocupou ainda a presidência da Matarazzo
-S.A.Holding e da Metalma S.A.
+S.A. Holding e da Metalma S.A.
 

--- a/text/11274.text
+++ b/text/11274.text
@@ -59,7 +59,7 @@ assumindo a presidência do partido no Estado.
 Na Câmara, passou a integrar em março de 2005, como membro
 titular, a Comissão Especial referente à Microempresa. Assumiu como
 terceiro vice-presidente a Comissão Permanente de Finanças e Tributação
-de 2005 a 2006.Em julho deste mesmo ano foi reeleito presidente da CNI
+de 2005 a 2006. Em julho deste mesmo ano foi reeleito presidente da CNI
 para o mandato 2006-2010. E em outubro  reelegeu-se deputado federal
 para a legislatura 2007-2011 pela legenda do PTB, integrante da
 coligação Pernambuco Melhor, formada pelo PTB, pelo Partido Republicano

--- a/text/11338.text
+++ b/text/11338.text
@@ -40,7 +40,7 @@ para o grupo.
 
 Candidatou-se à reeleição em 2006, porém, com pouco mais de 7 mil votos, não 
 obteve êxito. No ano seguinte, deixou o PPB e migrou para o Partido Social 
-Cristão (PSC).Em 2008, atuou como assessor especial da presidência da empresa 
+Cristão (PSC). Em 2008, atuou como assessor especial da presidência da empresa 
 Boa Vista Energia (Bovesa), subsidiária local da Eletronorte. Em abril do mesmo 
 ano, foi nomeado pelo prefeito de Boa Vista, Iradilson Sampaio, do Partido 
 Socialista Brasileiro (PSB-RR), diretor-presidente da Empresa de 

--- a/text/11403.text
+++ b/text/11403.text
@@ -105,7 +105,7 @@ Divisas. Em 2005 foi titular da Comissão Permanente de Constituição,
 Justiça e Cidadania. No ano seguinte foi titular na Comissão de
 Constituição, Justiça e Redação, bem como na Comissão de Defesa do
 Consumidor. Desta mesma comissão também foi titular em 2009. Atuou, em
-2006, na Comissão de Segurança Pública e Combate ao Crime Organizado.Em
+2006, na Comissão de Segurança Pública e Combate ao Crime Organizado. Em
 2009 foi titular e Suplente da Comissão de Trabalho, Administração e
 Serviço Público.
 

--- a/text/11480.text
+++ b/text/11480.text
@@ -13,7 +13,7 @@ Santos.
 
 Mudou-se para Cuiabá com a família em 1964. Após concluir o segundo
 grau, realizou curso técnico em estradas, na Escola Técnica Federal de
-Cuiabá, de 1976 a 1979.Neste último ano, iniciou a faculdade de
+Cuiabá, de 1976 a 1979. Neste último ano, iniciou a faculdade de
 ciências, na Universidade Federal do Mato Grosso (UFMT) e concluiu o
 curso em 1982. Em 1984, ingressou na faculdade de direito, na mesma
 universidade, e concluiu o curso em 1988.

--- a/text/11524.text
+++ b/text/11524.text
@@ -119,7 +119,7 @@ Arruda. No mesmo mês reassumiu seu mandado como deputado federal pelo DEM na
 Câmara dos Deputados. Em maio, foi julgado e, desta vez, condenado pela maioria 
 dos ministros do STF por crime de responsabilidade referente à convênios 
 firmados enquanto prefeito de Curitiba, porém, na ocasião do julgamento, o 
-supostos ilícitos já haviam prescrito.Não concorreu à reeleição no pleito de 
+supostos ilícitos já haviam prescrito. Não concorreu à reeleição no pleito de 
 Outubro daquele ano, tendo deixado seu mandato em dezembro. Em janeiro de 2011, 
 foi nomeado secretario de planejamento do Paraná, a convite do governador 
 recém-empossado, Beto Richa.

--- a/text/11541.text
+++ b/text/11541.text
@@ -93,7 +93,7 @@ nome aparecia como um dos parlamentares beneficiados pelos “atos
 secretos”, e  explicou que jamais se beneficiou ou chancelou qualquer
 ato daquela natureza, lavrado, sem a devida publicação, por Agaciel da
 Silva Maia enquanto este exercia o cargo de diretor-geral do Senado
-Federal.Por esta razão, Demóstenes Torres pedia a imediata instauração
+Federal. Por esta razão, Demóstenes Torres pedia a imediata instauração
 de um processo administrativo que, após julgamento dos fatos, resultasse
 na demissão de Agaciel Maia do Senado Federal.
 

--- a/text/11600.text
+++ b/text/11600.text
@@ -28,7 +28,7 @@ Escola», publicação mensal destinada ao ensino médio.
 Até 2005 «Carta Capital» não era filiada ao Instituto Verificador de
 Circulação (IVC). O primeiro relatório do IVC, após a filiação nesse
 ano, divulgou que a circulação líquida da revista fora de 40.113
-exemplares no mês de junho.Foi também divulgado um aumento de 43% no
+exemplares no mês de junho. Foi também divulgado um aumento de 43% no
 faturamento em publicidade no primeiro semestre de 2005 em comparação
 com o mesmo período do ano anterior.
 

--- a/text/12018.text
+++ b/text/12018.text
@@ -62,6 +62,6 @@ correspondentes a 61,3% do total válido.
 Retomou o exercício do mandato parlamentar após as eleições, tendo proposto, no 
 último trimestre de 2012, alguns projetos de lei relativos a tributos e 
 credenciamentos de medicamentos diversos. Encerrado o ano, deixou a Câmara ser 
-então novamente empossado prefeito de Serra, em Janeiro seguinte.Casou-se com a 
+então novamente empossado prefeito de Serra, em Janeiro seguinte. Casou-se com a 
 médica Mara Rejane, com quem teve dois filhos. 
 

--- a/text/12126.text
+++ b/text/12126.text
@@ -12,7 +12,7 @@ autor:
 filho de Hélio Batista Pimenta e Isabel Sampaio Pimenta. 
 
 Concluiu o ensino médio em 1983 no Centro Educacional de Esplanada, em 
-Esplanada (BA). Atuou como agricultor e empresário em Ibicoara (BA).Foi 
+Esplanada (BA). Atuou como agricultor e empresário em Ibicoara (BA). Foi 
 presidente do Sindicato dos Trabalhadores Rurais de Ibicoara (BA) em 1990 e  
 vice-presidente (1990-1995) e presidente (1995-2006) da Federação dos 
 Trabalhadores na Agricultura no Estado da Bahia (Fetag-BA). Participou, como 

--- a/text/12170.text
+++ b/text/12170.text
@@ -43,7 +43,7 @@ Vacaria, Lajeado e Canoas, até voltar a Porto Alegre.
 Em agosto de 1991 foi promovida por merecimento ao cargo de juíza do TRT4.  
 
 Em 1989 deu início ao magistério, tornando-se professora da Faculdade de 
-Direito da Pontifícia Universidade Católica do Rio Grande do Sul (PUC-RS).De 
+Direito da Pontifícia Universidade Católica do Rio Grande do Sul (PUC-RS). De 
 março de 1994 a dezembro de 1996, foi juíza-presidente da 5ª Turma do TRT4 e, 
 em abril de 1995 passou a integrar o Órgão Especial, colegiado mais importante 
 do Tribunal, no qual permaneceu até 2005. Neste período, exerceu diversas 

--- a/text/1513.text
+++ b/text/1513.text
@@ -214,7 +214,7 @@ contava ainda com o PT, PC do B e PRB, teve como candidato a vice-governador o
 petista Patrus Ananias, ex-prefeito de Belo Horizonte e também ex-ministro do 
 governo Lula (2003-2010). Receberam 3.419.622 votos, tendo sido, porém, 
 derrotados em primeiro turno pelo então governador, Antonio Anastasia, do PSDB, 
-que obteve mais de 6 milhões de votos.Encerrou seu mandato no Senado Federal em 
+que obteve mais de 6 milhões de votos. Encerrou seu mandato no Senado Federal em 
 Janeiro de 2011.
 
 Publicitário, tradutor e redator, como correspondente internacional realizou 

--- a/text/178.text
+++ b/text/178.text
@@ -349,7 +349,7 @@ o candidato do PSB, apoiado pelo governador Marcelo Deda, Valadares Filho. Com
 prefeitura após mais de trinta anos, em Janeiro de 2013.
 
 Em Março, o STJ aceitou a denúncia oferecida, cinco anos antes, pelo MPF, 
-contra João Alves Filho e outros 11 envolvidos no caso.João Alves Filho, desde 
+contra João Alves Filho e outros 11 envolvidos no caso. João Alves Filho, desde 
 1993, é membro da Academia Sergipana de Letras e autor de diversos livros, 
 entre os quais «No outro lado do mundo» (1988), «Irmãos de raça» (s/d), «O 
 Caminhoneiro do Brasil» (1994), «Nordeste – estratégias para o sucesso» (1997), 

--- a/text/2124.text
+++ b/text/2124.text
@@ -30,7 +30,7 @@ peemedebista à prefeitura de Cuiabá, mas foi derrotado por Frederico
 Campos, do Partido da Frente Liberal (PFL).
 
 Em 1990, ingressou no Partido Trabalhista Brasileiro (PTB) e elegeu-se
-deputado estadual, mais uma vez, em outubro de 1990.Empossado em
+deputado estadual, mais uma vez, em outubro de 1990. Empossado em
 fevereiro do ano seguinte, em 1994 deixou o PTB e filiou-se ao Partido
 da Social Democracia Brasileira (PSDB). Em outubro desse mesmo ano,
 disputou uma cadeira na Câmara dos Deputados pela sua nova legenda.

--- a/text/2306.text
+++ b/text/2306.text
@@ -113,7 +113,7 @@ vereador naquele município.
 
 Em abril de 2009, no entanto, foi mais uma vez acusado de
 irregularidades, desta vez pelo novo prefeito eleito de Caruaru, José
-Queirós (PDT), correligionário de José Lira.Na ocasião, Toni Gel afirmou
+Queirós (PDT), correligionário de José Lira. Na ocasião, Toni Gel afirmou
 que as denúncias não passavam de manobras políticas do adversário,
 ameaçando entrar na Justiça contra Queirós. Poucos meses depois, já em
 setembro, foi a vez de Toni Gel criticar publicamente a gestão de seu

--- a/text/2689.text
+++ b/text/2689.text
@@ -97,7 +97,7 @@ vice-governador do estado em 31 de dezembro de 1998, ao final do
 exercício do mandato.
 
 Em 1999, foi designado para ocupar a presidência da Fundação Nacional do
-Índio (Funai).No exercício do cargo, defendeu a criação da reserva
+Índio (Funai). No exercício do cargo, defendeu a criação da reserva
 indígena Raposa Serra do Sol, em Roraima, uma extensa área afinal
 demarcada oficialmente somente uma década depois, no ano de 2009.
 

--- a/text/2917.text
+++ b/text/2917.text
@@ -65,7 +65,7 @@ de Minas e Energia.
 Em novembro de 1978 reelegeu-se deputado federal. Com a extinção do
 bipartidarismo em 29 de novembro de 1979 e a conseqüente reformulação
 partidária, filiou-se à nova agremiação governista, o Partido
-Democrático Social (PDS), que sucedeu a Arena.Em 1980 tornou-se
+Democrático Social (PDS), que sucedeu a Arena. Em 1980 tornou-se
 vice-líder do partido Nessa legislatura tornou-se presidente da Comissão
 de Constituição e Justiça e integrou, em 1980, a Comissão Parlamentar de
 Inquérito (CPI) instituída para apurar atos de corrupção praticados por

--- a/text/2960.text
+++ b/text/2960.text
@@ -471,7 +471,7 @@ mesmo estando licenciados do cargo. Foi o caso dos ministros Alfredo
 Nascimento, dos Transportes; Hélio Costa, das Comunicações; e Édison
 Lobão – cuja assessoria informou que ele pedira a suspensão do
 benefício. O nome de Lobão foi também citado em reportagem do jornal
-«Folha de S.Paulo» publicada em junho de 2009 que denunciou a efetivação
+«Folha de S. Paulo» publicada em junho de 2009 que denunciou a efetivação
 de funcionários sem concurso público por meio de atos secretos editados
 durante sua gestão como presidente do Senado em 2001.
 

--- a/text/2995.text
+++ b/text/2995.text
@@ -143,7 +143,7 @@ constitucionais. No dia 28 recebeu ordens de Denis no sentido de pôr fim
 ao movimento de resistência encabeçado por Brizola, agindo com toda
 energia e, se preciso, deslocando tropas do interior em direção a Porto
 Alegre para tomar de assalto o palácio Piratini, sede do governo
-estadual.Caso fosse necessário, deveria, inclusive, empregar a
+estadual. Caso fosse necessário, deveria, inclusive, empregar a
 Aeronáutica para bombardeios ao palácio. Segundo denúncia formulada no
 Congresso naquele momento pelo deputado Rui Ramos, do Partido
 Trabalhista Brasileiro (PTB) do Rio Grande do Sul, as instruções do

--- a/text/3053.text
+++ b/text/3053.text
@@ -38,7 +38,7 @@ Federação das Indústrias.
 
 No pleito de outubro de 1992, na legenda do PMDB, elegeu-se prefeito de 
 Aparecida de Goiânia, renunciando ao mandato de deputado estadual em dezembro e 
-sendo empossado no mês seguinte.Em outubro de 1994, elegeu-se deputado federal 
+sendo empossado no mês seguinte. Em outubro de 1994, elegeu-se deputado federal 
 com 61 mil votos, tendo sido o segundo candidato mais votado do PMDB e do 
 estado. Empossado em fevereiro de 1995, participou dos trabalhos legislativos 
 como titular da Comissão de Trabalho, Administração e Serviço Público e como 

--- a/text/3129.text
+++ b/text/3129.text
@@ -495,7 +495,7 @@ de Acompanhamento da Crise Financeira e da Empregabilidade.
 
 Em maio de 2005, com a eclosão do “escândalo do mensalão” - esquema de compra 
 de votos de parlamentares da base aliada do governo Lula para que eles 
-aprovassem as matérias de interesse do governo..Diante da crise, Maciel 
+aprovassem as matérias de interesse do governo. Diante da crise, Maciel 
 afirmava que aquela poderia ser uma boa oportunidade para modificar seu sistema 
 partidário, fortalecendo mais as legendas em detrimento dos candidatos. 
 Favorável à realização de investigações do envolvimento de parlamentares 

--- a/text/3220.text
+++ b/text/3220.text
@@ -490,7 +490,7 @@ transformação do Congresso em assembléia nacional constituinte e “a
 volta simples do presidente Café Filho ao exercício da presidência”.
 
 No dia 21 de novembro, Café Filho, já restabelecido da doença que o
-afastara da chefia do governo, decidiu retornar.Os chefes militares
+afastara da chefia do governo, decidiu retornar. Os chefes militares
 todavia, não permitiram, considerando-o suspeito também de envolvimento
 com os setores interessados em impedir a posse de Juscelino e João
 Goulart. Em vista disso, o Congresso Nacional decidiu votar o

--- a/text/3466.text
+++ b/text/3466.text
@@ -202,7 +202,7 @@ negou todas as acusações.
 
 Nesse mesmo ano, concorreu à prefeitura da capital
 amazonense, mas perdeu para Serafim Corrêa, candidato do Partido
-Socialista Brasileiro (PSB).O pleito, decidido no segundo turno, deu a
+Socialista Brasileiro (PSB). O pleito, decidido no segundo turno, deu a
 vitória a Corrêa, que se recuperou do número menor de votos no primeiro
 turno. O candidato do PSB recebera 51,68% dos votos contra 48,31% de
 Mendes. 

--- a/text/3667.text
+++ b/text/3667.text
@@ -13,7 +13,7 @@ Silveira da Mota.
 
 Em 1948 tornou-se bacharel em ciências jurídicas e sociais pela
 Faculdade de Direito da Universidade de São Paulo (USP), ingressando,
-por concurso, no serviço diplomático brasileiro em 1950.Como
+por concurso, no serviço diplomático brasileiro em 1950. Como
 terceiro-secretário, trabalhou no consulado geral do Brasil em Montreal,
 Canadá, de 1952 a 1953. Neste último ano, foi transferido para a missão
 permanente do Brasil junto à Organização das Nações Unidas (ONU), em

--- a/text/3676.text
+++ b/text/3676.text
@@ -13,7 +13,7 @@ autor:
 ---
 
 «Luís de Gonzaga Fonseca Mota» nasceu em Fortaleza no dia 9 de dezembro de 
-1942, filho de Fernando Cavalcanti Mota e de Maria Helena Fonseca Mota.Fez 
+1942, filho de Fernando Cavalcanti Mota e de Maria Helena Fonseca Mota. Fez 
 curso secundário no Colégio Cearense do Sagrado Coração, tendo ingressado no 
 ano de 1964 nas Faculdades Econômicas e Administrativas da Universidade Federal 
 do Ceará (UFC) para estudar economia, diplomando-se em 1967. Estagiou na 

--- a/text/4110.text
+++ b/text/4110.text
@@ -111,7 +111,7 @@ para mães adotivas.
 
 Deixou a Câmara em 2002, ao final do seu mandato, e neste mesmo ano
 concorreu, nas eleições de outubro, ao governo do estado do Amapá na
-legenda do PMDB, mas não obteve êxito.Terminou em quarto lugar, tendo
+legenda do PMDB, mas não obteve êxito. Terminou em quarto lugar, tendo
 sido vencedor daquele pleito o candidato Waldez Góis, do Partido
 Democrático Trabalhista (PDT), que em 2004 convidou-a para ocupar o
 cargo de secretária de Turismo do Estado, função que Fátima Pelaes

--- a/text/4368.text
+++ b/text/4368.text
@@ -89,7 +89,7 @@ Assumiu o novo mandato na Câmara em fevereiro de 1999. Nesta
 legislatura, teve como missões oficiais uma visita de trabalho a vários
 países da Europa, para debate sobre comércio internacional e política
 agrícola e agrária, inclusive, em 2000, uma visita oficial a Portugal, a
-convite da Confederação Nacional da Agricultura daquele país.No ano
+convite da Confederação Nacional da Agricultura daquele país. No ano
 seguinte, participou da II Assembléia Latino-americana de Mulheres
 Rurais, do III Congresso Latino-americano de Organizações do Campo, na
 Cidade do México, e do Encontro Hemisférico de Luta contra a Área de

--- a/text/4379.text
+++ b/text/4379.text
@@ -202,7 +202,7 @@ Internacional S.A. BMI.
 Publicou vários artigos, além dos livros «Mercosul: um atlas cultural,
 social e econômico» (1997) em parceria com Felix Peña e
 «Zona internacional de serviços: rede para redes: integrando a América 
-Latina» (2004) com Martius V.Rodrigues e Renilda O. de Almeida.
+Latina» (2004) com Martius V. Rodrigues e Renilda O. de Almeida.
 
 Casou-se com Maria Letícia de Sousa Campos Protásio, com quem teve três
 filhos.

--- a/text/4381.text
+++ b/text/4381.text
@@ -8,7 +8,7 @@ cargos:
 autor: 
  - Márcia Quarti
  - Cristiane Jalles
- - Patrícia S.Monnerat
+ - Patrícia S. Monnerat
 ---
 
 «André Puccinelli» nasceu em Villaregio, nas proximidades de Parma, na Itália, 

--- a/text/4687.text
+++ b/text/4687.text
@@ -45,7 +45,7 @@ Brasileiro de Cirurgia promovido pelo Colégio Brasileiro de Cirurgiões.
 Em 1968 participou do Congresso Comemorativo do 30° aniversário do
 Serviço Nacional do Câncer, no Rio de Janeiro, e do V Congresso da
 Associação Médica Brasileira, em Caxambu (MG).Assumiu nesse ano a
-presidência do Centro de Estudos Dr.Carlos Firpo, do Hospital Santa
+presidência do Centro de Estudos Dr. Carlos Firpo, do Hospital Santa
 Isabel de Aracaju, e se filiou à Aliança Renovadora Nacional (Arena),
 partido que dava sustentação política ao período militar instaurado no
 Brasil em abril de 1964. Elegeu-se deputado federal em novembro de 1970

--- a/text/4799.text
+++ b/text/4799.text
@@ -35,7 +35,7 @@ Nacional de Secretários da Agricultura, e representou o estado no
 Encontro Técnico Cultural realizado em Sevilha, na Espanha.
 
 Em julho de 1993 deixou a pasta da Agricultura e desligou-se do PDT,
-ingressando no Partido Socialista Brasileiro (PSB).Tendo como reduto
+ingressando no Partido Socialista Brasileiro (PSB). Tendo como reduto
 eleitoral o município de Nova Venécia, concorreu a uma vaga na Câmara
 dos Deputados, em outubro de 1994, e foi eleito. Assumindo o mandato em
 fevereiro de 1995, tornou-se membro da Comissão de Agricultura e

--- a/text/481.text
+++ b/text/481.text
@@ -76,7 +76,7 @@ fora aprovado em 2002 por unanimidade na Câmara dos Deputados.
 Em junho de 2005, denúncias do deputado Roberto Jefferson sobre um esquema de 
 compra, pelo PT, de votos de parlamentares da base aliada do governo 
 desencadearam grave crise política que ficou conhecida como o escândalo do 
-“mensalão”. Reportagem publicada pelo jornal «Folha de S.Paulo» em 27 de julho 
+“mensalão”. Reportagem publicada pelo jornal «Folha de S. Paulo» em 27 de julho 
 citou documentos que faziam menção a depósitos feitos a partir de conta da 
 agência SMPB, do publicitário Marcos Valério Fernandes de Sousa, apontado por 
 Jefferson como operador do “mensalão”, em benefício de políticos mineiros 

--- a/text/4915.text
+++ b/text/4915.text
@@ -171,7 +171,7 @@ setor público do Estado do Rio Grande do Sul. Em janeiro de 1989, a
 entidade lançou um documento baseado nesse diagnóstico, intitulado «Rio
 Grande do Sul: eficácia na administração - avaliação do setor público».
 
-Em março de 1993, tornou-se articulista do jornal «Folha de S.Paulo»,
+Em março de 1993, tornou-se articulista do jornal «Folha de S. Paulo»,
 escrevendo artigos na coluna “Opinião Econômica”.
 
 Nesse mesmo mês, em seminário sobre reforma fiscal realizado em São
@@ -223,7 +223,7 @@ usufruísse as vantagens da dolarização. Em contrapartida, era pouco
 prudente na sobrevalorização do real em relação ao dólar, provocando a
 destruição do «superávit» comercial.
 
-Em fevereiro de 1996, em debate promovido pela «Folha de S.Paulo», Sayad
+Em fevereiro de 1996, em debate promovido pela «Folha de S. Paulo», Sayad
 afirmava que se fizesse parte da equipe econômica do governo mudaria
 duas coisas na implantação e na condução do Plano Real. Não reduziria as
 tarifas de importação da forma drástica como fora feito, mas faria a

--- a/text/506.text
+++ b/text/506.text
@@ -229,7 +229,7 @@ disputou novamente uma vaga de deputado federal, mas permaneceu como suplente.
 Deixou a Câmara ao final da legislatura, em janeiro de 2007.
 
 Manteve-se filiado ao PSDB, mas afastou-se da política, passando a se dedicar 
-exclusivamente à carreira acadêmica.Casou-se com Lourdes Maria Coelho Barelli, 
+exclusivamente à carreira acadêmica. Casou-se com Lourdes Maria Coelho Barelli, 
 com quem teve três filhos.
 
 Entre outras, publicou as seguintes obras: Pesquisa de cargos e funções (1974), 

--- a/text/5097.text
+++ b/text/5097.text
@@ -547,7 +547,7 @@ voltou atrás e decidiu aceitar a indicação.
 
 Em janeiro de 2009, criticou a oposição do senador José Sarney ao ingresso da 
 Venezuela no Mercosul, alegando que tal atitude seria “equivocada” e que 
-poderia transformar o país vizinho em “inimigo”.Também criticou a candidatura 
+poderia transformar o país vizinho em “inimigo”. Também criticou a candidatura 
 de José Sarney à presidência do Senado, vitoriosa em fevereiro de 2009. No 
 mesmo mês, Pedro Simon solidarizou-se com o colega Jarbas Vasconcelos (PMDB-PE) 
 - senador que, como ele, integrava a ala “dissidente” do PMDB, mais crítica ao 

--- a/text/5102.text
+++ b/text/5102.text
@@ -48,7 +48,7 @@ do general Ernesto Geisel (1974-1979) na Presidência da República em
 março de 1974, tornou-se diretor-geral do Departamento de Aeronáutica
 Civil (DAC), à frente do qual criou o Transporte Aéreo Regional. Exerceu
 a função até dezembro de 1975, quando assumiu a chefia do Estado-Maior
-da Aeronáutica (Emaer).Transferiu o cargo para o brigadeiro Délio Jardim
+da Aeronáutica (Emaer). Transferiu o cargo para o brigadeiro Délio Jardim
 de Matos em março de 1977 e nesse mesmo mês foi nomeado ministro do
 Superior Tribunal Militar (STM).
 

--- a/text/5127.text
+++ b/text/5127.text
@@ -206,7 +206,7 @@ Em outubro daquele ano, Soares filiou-se ao Partido Popular Socialista
 (PPS).
 
 Em julho de 2006, de acordo com notícia veiculada pelo portal «Folha
-Online», da «Folha de S.Paulo», duas emissoras de rádio de sua
+Online», da «Folha de S. Paulo», duas emissoras de rádio de sua
 propriedade foram incluídas numa lista de 225 canais de rádio e TV,
 solicitada ao Congresso pelo presidente Lula, para serem devolvidas à
 competência do Ministério das Comunicações, retiradas da esfera da

--- a/text/530.text
+++ b/text/530.text
@@ -142,7 +142,7 @@ inflamado, não... falava errado até”.
 Sempre procurando manter um bom relacionamento com o empresariado,
 Ademar criou em 1938 o Conselho de Expansão Econômica, voltado para
 formular propostas de política econômica e transmitir ao Conselho
-Federal de Comércio Exterior as sugestões de São Paulo.O próprio
+Federal de Comércio Exterior as sugestões de São Paulo. O próprio
 interventor assumiu a presidência desse órgão, integrado por
 representantes de importantes instituições econômicas, como Roberto
 Simonsen (pela Federação das Indústrias do Estado de São Paulo), Osvaldo

--- a/text/5368.text
+++ b/text/5368.text
@@ -87,7 +87,7 @@ Em julho de 1980, durante um almoço oferecido a Brizola em Montes
 Claros, proferiu um discurso acusando os generais Antônio Bandeira,
 comandante do III Exército, com sede em Porto Alegre, Mílton Tavares de
 Sousa, comandante do II Exército, sediado em São Paulo, e José Luís
-Coelho Neto, comandante da 4ª.Divisão de Exército, com sede em Belo
+Coelho Neto, comandante da 4ª Divisão de Exército, com sede em Belo
 Horizonte, de serem alguns dos líderes da chamada Operação Cristal, que
 estaria coordenando atentados terroristas e atos de violência de extrema
 direita. No mês seguinte, reafirmou esse pronunciamento perante a CPI do

--- a/text/5745.text
+++ b/text/5745.text
@@ -852,7 +852,7 @@ capitais estrangeiros no país pelo sistema de taxa de câmbio livre.
 Segundo sugestão do presidente do Banco do Brasil, foram destacados
 investimentos de interesse nacional que recebiam benefício fiscal de
 remessa de lucros de 10% por ano ao câmbio oficial, dependendo das
-possibilidades do balanço de pagamentos.Estes lucros poderiam ser
+possibilidades do balanço de pagamentos. Estes lucros poderiam ser
 incorporados ao capital registrado, quando reinvestidos na atividade.
 Através da Carteira de Exportação e Importação, foram facultadas ao
 Banco do Brasil a compra e a venda de qualquer produto; estes

--- a/text/5860.text
+++ b/text/5860.text
@@ -1219,7 +1219,7 @@ janeiro de 2007 o site ZAP. O site concentrava a versão online dos
 anúncios dos jornais «O Estado de S. Paulo», «Jornal da Tarde», «O Globo»,
 «Extra» e «O Diário de S. Paulo».
 
-O balanço de final de ano de 2007 do jornal «O Estado de S.Paulo»
+O balanço de final de ano de 2007 do jornal «O Estado de S. Paulo»
 agradou a direção da casa e sua equipe comercial. Segundo levantamento
 do Instituto Verificador de Circulação (IVC), a circulação do jornal
 cresceu acima da média dos grandes jornais, com 5% de crescimento
@@ -1235,7 +1235,7 @@ jornal do País com maior volume em circulação. Seu total de circulação
 média diária em 2008 fora de 246 mil exemplares, um crescimento de 8,2%
 em relação a 2007.
 
-A partir de agosto de 2009, o jornal «O Estado de S.Paulo» deu início a
+A partir de agosto de 2009, o jornal «O Estado de S. Paulo» deu início a
 uma série de mudanças em seu projeto gráfico e também em sua versão
 online, focando na cobertura da Copa do Mundo e das eleições
 presidenciais de 2010.

--- a/text/5904.text
+++ b/text/5904.text
@@ -395,7 +395,7 @@ reviravolta na política internacional brasileira: Cuba e União Soviética
 tornaram-se manchete, marcando a política de autodeterminação dos povos,
 francamente favorável aos países do Terceiro Mundo e hostil aos EUA. «A
 Gazeta» absorveu discretamente essa nova orientação da política externa
-do país.O editorial de 17 de fevereiro de 1961, intitulado “A política
+do país. O editorial de 17 de fevereiro de 1961, intitulado “A política
 externa brasileira”, afirmava: “Está definida a orientação política do
 presidente Jânio Quadros no setor internacional. Três decisões tomadas
 agora confirmam o ponto de vista do chefe do governo, preocupado em

--- a/text/5905.text
+++ b/text/5905.text
@@ -1226,7 +1226,7 @@ dos repórteres Angelina Nunes, Alan Gripp, Carla Rocha, Dimmi Amora,
 Flávio Pessoa, Luiz Ernesto Magalhães e Maiá Menezes, e que expôs a
 variação patrimonial de setenta parlamentares da Alerj entre 1996 e
 2001. A premiação, porém, criou polêmica entre diretores de redação de
-outros grandes veículos, como a «Folha» e o «Estado de S.Paulo», que
+outros grandes veículos, como a «Folha» e o «Estado de S. Paulo», que
 antes mesmo do anúncio do vencedor criticaram os organizadores do
 prêmio, questionando a representatividade dos jurados e suspeitando de
 favorecimento às empresas Globo. Também a revista «Veja» contestou a
@@ -1265,7 +1265,7 @@ reportagens sobre direitos humanos publicadas em todo o mundo.
 
 Em seu balanço de 2008, a Infoglobo, que publicava os jornais «O Globo»,
 «Extra», «Expresso da Informação» e «Diário de S. Paulo», além co-editar
-o «Valor Econômico» com o Grupo Folha de S.Paulo, divulgou que a receita
+o «Valor Econômico» com o Grupo Folha de S. Paulo, divulgou que a receita
 bruta do grupo fora de 1,027 bilhão de reais e o lucro líquido
 registrado, de R$ 172,9 milhões, com crescimento significativo em
 relação aos números do ano anterior: R$ 1,006 bi de recita bruta e 

--- a/text/5999.text
+++ b/text/5999.text
@@ -399,7 +399,7 @@ estabelecido com o presidente brasileiro, Luiz Inácio da Silva. Pelo novo
 acordo, o governo brasileiro triplicaria o valor pago pela energia comprada do 
 Paraguai, passando de US$120 milhões para US$ 360 milhões. O novo acordo, 
 entretanto, somente passou a ter vigência em maio de 2011, quando aprovado pelo 
-Senado brasileiro.Outra questão bilateral que afeta a dinâmica do bloco é a 
+Senado brasileiro. Outra questão bilateral que afeta a dinâmica do bloco é a 
 chamada “crise das papeleras”, entre Argentina e Uruguai, iniciada em 2005, com 
 a instalação, por parte do governo uruguaio, da indústria de celulose 
 finlandesa Botnia. às margens do rio Uruguai. Desde então, há manifestações de 

--- a/text/6228.text
+++ b/text/6228.text
@@ -140,7 +140,7 @@ candidato do Partido Renovador Trabalhista Brasileiro (PRTB), o advogado Fábio
 Tenório Cavalcanti, que terminou a disputa em nono lugar. Já em São Paulo o PSC 
 lançou a candidatura de Edson Falanga, que obteve apenas o penúltimo lugar. 
 Para o Congresso Nacional o partido elegeu dois deputados federais: Dino 
-Fernandes, do Rio de Janeiro, e Paulo Marinho, do Maranhão.Em 2000, o PSC 
+Fernandes, do Rio de Janeiro, e Paulo Marinho, do Maranhão. Em 2000, o PSC 
 apresentou concorreu a prefeitura de 170 municípios, elegendo 33 candidatos. Os 
 resultados mais expressivos da legenda foram obtidos, respectivamente, na 
 Bahia, em Minas Gerais e em Goiás.

--- a/text/6367.text
+++ b/text/6367.text
@@ -1390,7 +1390,7 @@ cobertura ao avanço dos soldados da 4ª Região Militar (Minas) e do II
 Exército (São Paulo).
 
 Na arca do II Exército, Rio Grande do Sul, os conspiradores esperavam
-encontrar grandes dificuldades.Temiam, sobretudo, a repetição do
+encontrar grandes dificuldades. Temiam, sobretudo, a repetição do
 “fenômeno de 1961”, quando o então governador Leonel Brizola comandou a
 “campanha da legalidade” que assegurou a posse de João Goulart. O
 general Ladário Pereira Teles, comandante do III Exército, determinou

--- a/text/827.text
+++ b/text/827.text
@@ -177,7 +177,7 @@ entanto, de acordo com o relato de Carlos Castelo Branco, durante um
 churrasco promovido no início de março por Goulart para os membros de
 seu Gabinete Militar, Assis Brasil continuou garantindo o apoio do
 dispositivo que montara à política de reformas do governo e o controle
-dos possíveis focos de agitação no meio militar.Teria afirmado também na
+dos possíveis focos de agitação no meio militar. Teria afirmado também na
 ocasião que asseguraria a tranqüilidade do presidente até o final de seu
 mandato e a posse de seu sucessor, excluindo-se apenas a possibilidade
 de Lacerda sair vitorioso na disputa presidencial.

--- a/text/8739.text
+++ b/text/8739.text
@@ -232,7 +232,7 @@ da Imprensa Católica, por iniciativa da Coligação Católica Brasileira.
 No início da década de 1940, Amoroso Lima, influenciado
 agora por Jacques Maritain, propôs, como base de uma nova
 plataforma para o Centro Dom Vital, a idéia de “humanismo integral”,
-rejeitando a ideologia integralista.Com a inauguração da Pontifícia
+rejeitando a ideologia integralista. Com a inauguração da Pontifícia
 Universidade Católica do Rio de Janeiro, em abril de 1941, aumentou a
 influência do centro. O cardeal Leme apontou o padre Leonel Franca para
 o cargo de reitor.

--- a/text/8882.text
+++ b/text/8882.text
@@ -291,7 +291,7 @@ de dezembro de 1950, provocou um esfriamento das relações da SRB com o
 Estado, bastante cordiais no mandato anterior, do general Euríco Gaspar
 Dutra. A sociedade reagiu prontamente às iniciativas governamentais no
 sentido de promover a reforma agrária, introduzir leis trabalhistas no
-campo e organizar sindicatos rurais.Em fevereiro de 1954, a SRB enviou
+campo e organizar sindicatos rurais. Em fevereiro de 1954, a SRB enviou
 um memorial ao general Aguinaldo Caiado de Castro, secretário-geral do
 Conselho de Segurança Nacional, no qual afirmava textualmente que a
 sindicalização do trabalhador rural era uma arma dos comunistas.


### PR DESCRIPTION

Neste PR vários erros de pontos finais de sentenças não seguidos por espaço são corrigidos. Este tipo de problema atrapalha o algoritmo de segmentação do texto em sentenças. Provavelmente estes erros são causados na conversão de Word para TXT. 

Também temos casos de `Folha de S.Paulo` vs `Folha de S. Paulo`. Procurei normalizar para sempre termos o `S.` seguido de espaço.